### PR TITLE
Run all Ruby tests in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,4 +29,5 @@ jobs:
       - name: Run tests
         run: |
           cd ruby
-          ruby *_test.rb
+          ruby bingo_board_test.rb
+          ruby bingo_board_bdd_test.rb


### PR DESCRIPTION
I realised only one of the test files was being executed.

(in a Ruby codebase, the tests would normally be run via a Rake task)